### PR TITLE
Fix initial field focus on web

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -200,6 +200,9 @@ export default class TextField extends PureComponent {
 
   componentDidMount() {
     this.mounted = true;
+    if (Platform.OS === 'web' && !this.focused && this.props.autoFocus) {
+      this.setFocused();
+    }
   }
 
   componentWillUnmount() {
@@ -315,6 +318,18 @@ export default class TextField extends PureComponent {
     this.setState({ text });
   }
 
+  setFocused() {
+    let { receivedFocus } = this.state;
+
+    this.focused = true;
+    this.startFocusAnimation();
+    this.startLabelAnimation();
+
+    if (!receivedFocus) {
+      this.setState({ receivedFocus: true, text: this.value() });
+    }
+  }
+
   isFocused() {
     let { current: input } = this.inputRef;
 
@@ -351,7 +366,6 @@ export default class TextField extends PureComponent {
 
   onFocus(event) {
     let { onFocus, clearTextOnFocus } = this.props;
-    let { receivedFocus } = this.state;
 
     if ('function' === typeof onFocus) {
       onFocus(event);
@@ -361,14 +375,7 @@ export default class TextField extends PureComponent {
       this.clear();
     }
 
-    this.focused = true;
-
-    this.startFocusAnimation();
-    this.startLabelAnimation();
-
-    if (!receivedFocus) {
-      this.setState({ receivedFocus: true, text: this.value() });
-    }
+    this.setFocused();
   }
 
   onBlur(event) {


### PR DESCRIPTION
On web the field doesn't always receive the onFocus event even though it has the focus. This caused it to not animate into focused style.

With this fix the field will explicitly animate into focus state on mount in case it has a truthy autoFocus prop 