### PR TITLE
Fix label width for native and web

### DIFF
--- a/src/components/field-filled/__snapshots__/test.js.snap
+++ b/src/components/field-filled/__snapshots__/test.js.snap
@@ -96,6 +96,7 @@ exports[`renders 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -265,6 +266,7 @@ exports[`renders accessory 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -433,6 +435,7 @@ exports[`renders counter 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -624,6 +627,7 @@ exports[`renders disabled value 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -792,6 +796,7 @@ exports[`renders title 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -977,6 +982,7 @@ exports[`renders value 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >

--- a/src/components/field-outlined/__snapshots__/test.js.snap
+++ b/src/components/field-outlined/__snapshots__/test.js.snap
@@ -216,6 +216,7 @@ exports[`renders 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -505,6 +506,7 @@ exports[`renders accessory 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -793,6 +795,7 @@ exports[`renders counter 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -1100,6 +1103,7 @@ exports[`renders disabled value 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -1388,6 +1392,7 @@ exports[`renders title 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -1693,6 +1698,7 @@ exports[`renders value 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >

--- a/src/components/field/__snapshots__/test.js.snap
+++ b/src/components/field/__snapshots__/test.js.snap
@@ -93,6 +93,7 @@ exports[`renders 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -258,6 +259,7 @@ exports[`renders counter 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -446,6 +448,7 @@ exports[`renders default value 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -611,6 +614,7 @@ exports[`renders disabled value 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -776,6 +780,7 @@ exports[`renders error 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -959,6 +964,7 @@ exports[`renders left accessory 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -1124,6 +1130,7 @@ exports[`renders multiline value 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -1295,6 +1302,7 @@ exports[`renders prefix 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -1482,6 +1490,7 @@ exports[`renders restriction 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -1670,6 +1679,7 @@ exports[`renders right accessory 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -1836,6 +1846,7 @@ exports[`renders suffix 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -2023,6 +2034,7 @@ exports[`renders title 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >
@@ -2205,6 +2217,7 @@ exports[`renders value 1`] = `
               "lineHeight": 16,
               "textAlign": "left",
               "textAlignVertical": "top",
+              "width": "200%",
             }
           }
         >

--- a/src/components/label/__snapshots__/test.js.snap
+++ b/src/components/label/__snapshots__/test.js.snap
@@ -33,6 +33,7 @@ exports[`renders active errored label 1`] = `
         "lineHeight": 16,
         "textAlign": "left",
         "textAlignVertical": "top",
+        "width": "200%",
       }
     }
   >
@@ -74,6 +75,7 @@ exports[`renders active focused label 1`] = `
         "lineHeight": 16,
         "textAlign": "left",
         "textAlignVertical": "top",
+        "width": "200%",
       }
     }
   >
@@ -115,6 +117,7 @@ exports[`renders active label 1`] = `
         "lineHeight": 16,
         "textAlign": "left",
         "textAlignVertical": "top",
+        "width": "200%",
       }
     }
   >
@@ -158,6 +161,7 @@ exports[`renders errored label 1`] = `
         "lineHeight": 16,
         "textAlign": "left",
         "textAlignVertical": "top",
+        "width": "200%",
       }
     }
   >
@@ -199,6 +203,7 @@ exports[`renders label 1`] = `
         "lineHeight": 16,
         "textAlign": "left",
         "textAlignVertical": "top",
+        "width": "200%",
       }
     }
   >
@@ -240,6 +245,7 @@ exports[`renders restricted label 1`] = `
         "lineHeight": 16,
         "textAlign": "left",
         "textAlignVertical": "top",
+        "width": "200%",
       }
     }
   >
@@ -282,6 +288,7 @@ exports[`renders styled label 1`] = `
         "textAlign": "left",
         "textAlignVertical": "top",
         "textTransform": "uppercase",
+        "width": "200%",
       }
     }
   >

--- a/src/components/label/styles.js
+++ b/src/components/label/styles.js
@@ -1,17 +1,30 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
 
 export default StyleSheet.create({
   container: {
     position: 'absolute',
     top: 0,
-    left: '-50%',
-    width: '100%',
-    paddingLeft: '50%',
+    ...(Platform.select({ web: {
+      left: '-100%',
+      width: '200%',
+      paddingLeft: '100%',
+    },
+    default: {
+      left: '-50%',
+      width: '100%',
+      paddingLeft: '50%',
+    } })),
   },
 
   text: {
     textAlign: 'left',
     includeFontPadding: false,
     textAlignVertical: 'top',
+    ...(Platform.select({ web: {
+      width: '100%',
+    },
+    default: {
+      width: '200%',
+    } })),
   },
 });


### PR DESCRIPTION
Issue: Label width was half the size is should be. Web and native require different styles to make it use the full width while keeping the transform animation correct.

Fix: Added platform specific styles to make it work correctly on both platforms