### PR TITLE
Expose methods to activate focused/blurred styles

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -98,9 +98,17 @@ declare module 'react-native-material-textfield' {
          */
         focus(): void;
         /*
+         * Set focused style
+         */
+        setFocused(): void;
+        /*
          * Release focus
          */
         blur(): void;
+        /*
+         * Set blurred style
+         */
+        setBlurred(): void;
         /*
          * Clear text field
          */

--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -330,6 +330,12 @@ export default class TextField extends PureComponent {
     }
   }
 
+  setBlurred() {
+    this.focused = false;
+    this.startFocusAnimation();
+    this.startLabelAnimation();
+  }
+
   isFocused() {
     let { current: input } = this.inputRef;
 
@@ -385,10 +391,7 @@ export default class TextField extends PureComponent {
       onBlur(event);
     }
 
-    this.focused = false;
-
-    this.startFocusAnimation();
-    this.startLabelAnimation();
+    this.setBlurred();
   }
 
   onChange(event) {


### PR DESCRIPTION
Exposes methods to activate focused/blurred styles which comes in handy sometimes (eg when using the field as label for a date picker). 